### PR TITLE
Update `DalamudPackager` to `11.0.0` & only attempt to position nodes that have been set up

### DIFF
--- a/ResizableHUD/AddonManager.cs
+++ b/ResizableHUD/AddonManager.cs
@@ -531,7 +531,7 @@ internal class AddonManager
         RaptureAtkUnitManager* manager = AtkStage.Instance()->RaptureAtkUnitManager;
         AtkUnitBase* unit = manager->GetAddonByName(node.Name);
 
-        if (unit != null) {
+        if (unit != null && unit->IsReady) {
             Vector2 size = RaptureAtkUnitManagerHelper.GetNodeScaledSize(unit->RootNode);
             Vector2 offset = GetAnchorOffset(node.Anchor, size);
             Vector2 pos = new Vector2(node.PosX - offset.X, node.PosY - offset.Y); // absolute top left

--- a/ResizableHUD/ResizableHUD.csproj
+++ b/ResizableHUD/ResizableHUD.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="DalamudPackager" Version="2.1.13" />
+		<PackageReference Include="DalamudPackager" Version="11.0.0" />
 	</ItemGroup>
 
 	<PropertyGroup>

--- a/ResizableHUD/packages.lock.json
+++ b/ResizableHUD/packages.lock.json
@@ -4,9 +4,9 @@
     "net8.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[2.1.13, )",
-        "resolved": "2.1.13",
-        "contentHash": "rMN1omGe8536f4xLMvx9NwfvpAc9YFFfeXJ1t4P4PE6Gu8WCIoFliR1sh07hM+bfODmesk/dvMbji7vNI+B/pQ=="
+        "requested": "[11.0.0, )",
+        "resolved": "11.0.0",
+        "contentHash": "bjT7XUlhIJSmsE/O76b7weUX+evvGQctbQB8aKXt94o+oPWxHpCepxAGMs7Thow3AzCyqWs7cOpp9/2wcgRRQA=="
       },
       "drahsidlib": {
         "type": "Project"


### PR DESCRIPTION
- Updated `DalamudPackager` to `11.0.0`
- Prevented attempts to position nodes that haven't been set up yet, e.g. when a job gauge is hidden by a sheathed weapon and the player's job is changed, the node will not be set up until the player unsheathes his or her weapon